### PR TITLE
SPA test for epacts-multi, beta estimation and optimized for large sample sizes

### DIFF
--- a/data/epactsMulti.R
+++ b/data/epactsMulti.R
@@ -2,7 +2,7 @@
 args <- commandArgs(trailingOnly=TRUE)
 bindir <- args[2]  ## Directory containing the R scripts
 phenof <- args[3]  ## phenotype file
-##covf <- args[4]    ## covariate file
+covf <- args[4]    ## covariate file or null model index file
 indf <- args[5]    ## individual IDs (in order from VCF)
 vcf <- args[6]     ## VCF file - must be bgzipped and tabixed
 region <- args[7]  ## Genomic region to load
@@ -29,9 +29,20 @@ dyn.load(paste(bindir,"/lib/epactsR/libs/epactsR",.Platform$dynlib.ext, sep=""))
 pnames <- scan(phenof,what=character(),nlines=1)[-1]
 phenos <- as.matrix(read.table(phenof)[,-1])
 
+if(test=="multi.b.sna2")
+{
+	nullf<-substr(covf,1,nchar(covf)-4)	#remove ".cov" to get outf
+} else if ( covf == "NULL" ) {
+  cov <- NULL
+} else {
+  cov <- as.matrix(read.table(covf)[,-1])
+}
+
+
 ind <- as.integer(read.table(indf)[,2])-1
 
 G <- .Call("readVcf",vcf,region,field,passOnly,ind,NULL)
+
 m <- nrow(G)
 if ( m > 0 ) {
   n <- ncol(G)
@@ -61,19 +72,23 @@ if ( m > 0 ) {
 
   print("bar")
   
-  out <- matrix(NA,m,4+2*ncol(phenos))
-  out[vids,3+(1:ncol(phenos))*2] <- r$p
-  out[vids,4+(1:ncol(phenos))*2] <- r$b
+  out <- matrix(NA,m,4+ncol(r$p)+ncol(r$add))
+  out[vids,4+(1:ncol(r$p))] <- r$p
+  out[vids,4+ncol(r$p)+(1:ncol(r$add))] <- r$add
   out[,1] <- NS
   out[,2] <- AC
   out[,3] <- CR
   out[,4] <- MAF
-  colnames(out) <- c("NS","AC","CR","MAF",rep(NA,2*ncol(phenos)))
-  colnames(out)[3+(1:ncol(phenos))*2] <- paste(pnames,"P",sep=".")
-  colnames(out)[4+(1:ncol(phenos))*2] <- paste(pnames,"B",sep=".")
+  colnames(out) <- c("NS","AC","CR","MAF",rep(NA,ncol(r$p)),rep(NA,ncol(r$add)))
+  colnames(out)[4+(1:ncol(r$p))] <- paste(pnames,"P",sep=".")
+  colnames(out)[4+ncol(r$p)+(1:ncol(r$add))] <- r$cname
   rownames(out) <- rownames(G)
+
   print(warnings())
   .Call("writeMatrix",out,outf)
 } else {
   write.table(NULL,outf,row.names=F,col.names=F)  
 }
+rm(list=ls())
+gc()
+

--- a/data/epactsMultiNull.R
+++ b/data/epactsMultiNull.R
@@ -1,0 +1,80 @@
+args <- commandArgs(trailingOnly=TRUE)
+nullf <- args[2]  ## output name
+phenof <- args[3]  ## phenotype file
+covf <- args[4]    ## covariate file or null model index file
+
+pnames <- scan(phenof,what=character(),nlines=1)[-1]
+phenos <- as.matrix(read.table(phenof)[,-1])
+
+if ( covf == "NULL" ) {
+  cov <- NULL;
+} else {
+  cov <- as.matrix(read.table(covf)[,-1])
+}
+
+
+
+ScoreTest_wSaddleApprox_Get_X1 = function(X1)
+{
+	q1<-ncol(X1)
+	if(q1>=2)
+	{
+		if(sum(abs(X1[,1]-X1[,2]))==0)
+		{
+			X1=X1[,-2]
+			q1<-q1-1
+		}
+	}
+	qr1<-qr(X1)
+	if(qr1$rank < q1){
+		
+		X1.svd<-svd(X1)
+		X1 = X1.svd$u[,1:qr1$rank]
+	} 
+
+	return(X1)
+}
+
+
+ScoreTest_wSaddleApprox_NULL_Model <- function(formula, data=NULL)
+{
+	X1<-model.matrix(formula,data=data)
+	X1<-ScoreTest_wSaddleApprox_Get_X1(X1)
+	
+	glmfit= glm(formula, data=data, family = "binomial")
+  	mu    = glmfit$fitted.values
+	V = mu*(1-mu)
+  	res = glmfit$y- mu
+	n1<-length(res)
+	
+	XV = t(X1 * V)
+	XVX_inv= solve(t(X1)%*%(X1 * V))
+	XXVX_inv= X1 %*% XVX_inv   
+	
+	re<-list(y=glmfit$y, mu=mu, res=res, V=V, X1=X1, XV=XV, XXVX_inv =XXVX_inv)
+	class(re)<-"SA_NULL"
+	return(re)	
+}
+
+##################################################################
+## MAIN FUNCTION:  null.b.sna2
+##################################################################
+
+phenos <- phenos - min(phenos,na.rm=T)
+
+    k <- ncol(cov)
+
+g<-ncol(phenos)
+
+	for(gind in 1:g)
+	{
+	nm<-which(is.na(phenos[,gind])==FALSE)
+	pheno<-phenos[nm,gind]
+	cov1<-cov[nm,]
+
+	obj.null<-ScoreTest_wSaddleApprox_NULL_Model(pheno ~as.matrix(cov1))
+        save.image(paste(nullf,".",pnames[gind],".null.RData",sep=""))
+
+   	 }
+
+

--- a/data/epactsMultiNull.R
+++ b/data/epactsMultiNull.R
@@ -51,7 +51,7 @@ ScoreTest_wSaddleApprox_NULL_Model <- function(formula, data=NULL)
 	XVX_inv= solve(t(X1)%*%(X1 * V))
 	XXVX_inv= X1 %*% XVX_inv   
 	
-	re<-list(y=glmfit$y, mu=mu, res=res, V=V, X1=X1, XV=XV, XXVX_inv =XXVX_inv)
+	re<-list(y=glmfit$y, cov=X1, mu=mu, res=res, V=V, X1=X1, XV=XV, XXVX_inv =XXVX_inv)
 	class(re)<-"SA_NULL"
 	return(re)	
 }

--- a/data/epactsSingleNull.R
+++ b/data/epactsSingleNull.R
@@ -1,0 +1,69 @@
+args <- commandArgs(trailingOnly=TRUE)
+nullf <- args[2]  ## output name
+phenof <- args[3]  ## phenotype file
+covf <- args[4]    ## covariate file or null model index file
+
+pheno <- as.matrix(read.table(phenof)[,-1])
+
+if ( covf == "NULL" ) {
+  cov <- NULL;
+} else {
+  cov <- as.matrix(read.table(covf)[,-1])
+}
+
+
+ScoreTest_wSaddleApprox_Get_X1 = function(X1)
+{
+	q1<-ncol(X1)
+	if(q1>=2)
+	{
+		if(sum(abs(X1[,1]-X1[,2]))==0)
+		{
+			X1=X1[,-2]
+			q1<-q1-1
+		}
+	}
+	qr1<-qr(X1)
+	if(qr1$rank < q1){
+		
+		X1.svd<-svd(X1)
+		X1 = X1.svd$u[,1:qr1$rank]
+	} 
+
+	return(X1)
+}
+
+
+ScoreTest_wSaddleApprox_NULL_Model <- function(formula, data=NULL)
+{
+	X1<-model.matrix(formula,data=data)
+	X1<-ScoreTest_wSaddleApprox_Get_X1(X1)
+	
+	glmfit= glm(formula, data=data, family = "binomial")
+  	mu    = glmfit$fitted.values
+	V = mu*(1-mu)
+  	res = glmfit$y- mu
+	n1<-length(res)
+	
+	XV = t(X1 * V)
+	XVX_inv= solve(t(X1)%*%(X1 * V))
+	XXVX_inv= X1 %*% XVX_inv   
+	
+	re<-list(y=glmfit$y, mu=mu, res=res, V=V, X1=X1, XV=XV, XXVX_inv =XXVX_inv)
+	class(re)<-"SA_NULL"
+	return(re)	
+}
+
+##################################################################
+## MAIN FUNCTION:  null.b.sna2
+##################################################################
+
+pheno <- pheno - min(pheno,na.rm=T)
+    k <- ncol(cov)
+
+	obj.null<-ScoreTest_wSaddleApprox_NULL_Model(pheno ~as.matrix(cov))
+        save.image(paste(nullf,".null.RData",sep=""))
+
+
+
+

--- a/data/epactsSingleNull.R
+++ b/data/epactsSingleNull.R
@@ -49,7 +49,7 @@ ScoreTest_wSaddleApprox_NULL_Model <- function(formula, data=NULL)
 	XVX_inv= solve(t(X1)%*%(X1 * V))
 	XXVX_inv= X1 %*% XVX_inv   
 	
-	re<-list(y=glmfit$y, mu=mu, res=res, V=V, X1=X1, XV=XV, XXVX_inv =XXVX_inv)
+	re<-list(y=glmfit$y, cov=X1, mu=mu, res=res, V=V, X1=X1, XV=XV, XXVX_inv =XXVX_inv)
 	class(re)<-"SA_NULL"
 	return(re)	
 }

--- a/scripts/epacts-multi
+++ b/scripts/epacts-multi
@@ -373,27 +373,33 @@ if ( $test eq "q.emmax" ) {  ## Need to generate kinship matrix and REML first
     close MAK;
 
 }
-else {
-    if ( !( $invNorm ) && ( $#covs >= 0 ) ) {
-	print STDERR "Performing inverse normal transformation of phenotypes\n";
-	open(R,">$out.regress.R") || die "Cannot open file $out.regress.R for writing\n";
-	print R "t5 <- read.table('$out.phe',nrows=2)\n";
-	print R "classes <- sapply(t5,class)\n";
-	print R "T <- read.table('$out.phe',colClasses=classes)\n";
-	print R "n <- as.matrix(T[,1])\n";
-	print R "Y <- as.matrix(T[,-1])\n";
-	print R "c <- as.matrix(read.table('$out.cov')[,-1])\n";
-	print R "R <- cbind(n, apply(Y,2,function(x) { lm(x~c)\$residual }))\n";
-	print R "colnames(R) <- scan('$out.phe',what=character(),nlines=1)\n";
-	print R "write.table(R,'$out.phe',row.names=FALSE,col.names=TRUE,quote=FALSE,sep=\"\t\")\n";
-	close R;
-	my $cmd = "$binRscript $out.regress.R --vanilla";
-	if ( $mosixNodes ) { $cmd = &getMosixCmd($cmd,$mosixNodes); }
-	&forkExecWait($cmd);
-	@covs = (); ## don't regress out covariates any more
-	unlink("$out.regress.R");
-    }
-    
+else {	
+#    if ( !( $invNorm ) && ( $#covs >= 0 ) ) {
+#	print STDERR "Performing inverse normal transformation of phenotypes\n";
+#	open(R,">$out.regress.R") || die "Cannot open file $out.regress.R for writing\n";
+#	print R "t5 <- read.table('$out.phe',nrows=2)\n";
+#	print R "classes <- sapply(t5,class)\n";
+#	print R "T <- read.table('$out.phe',colClasses=classes)\n";
+#	print R "n <- as.matrix(T[,1])\n";
+#	print R "Y <- as.matrix(T[,-1])\n";
+#	print R "c <- as.matrix(read.table('$out.cov')[,-1])\n";
+#	print R "R <- cbind(n, apply(Y,2,function(x) { lm(x~c)\$residual }))\n";
+#	print R "colnames(R) <- scan('$out.phe',what=character(),nlines=1)\n";
+#	print R "write.table(R,'$out.phe',row.names=FALSE,col.names=TRUE,quote=FALSE,sep=\"\t\")\n";
+#	close R;
+#	my $cmd = "$binRscript $out.regress.R --vanilla";
+#	if ( $mosixNodes ) { $cmd = &getMosixCmd($cmd,$mosixNodes); }
+#	&forkExecWait($cmd);
+#	@covs = (); ## don't regress out covariates any more
+#	unlink("$out.regress.R");
+#    }
+
+if ( $test eq "b.sna2" ) {	#Analyze Null model
+my $cmdn = "$binRscript $datadir/epactsMultiNull.R --vanilla $out $pheno $cov;";
+if ( $mosixNodes ) { $cmdn = &getMosixCmd($cmdn,$mosixNodes); }
+&forkExecWait($cmdn);
+}
+ 
     my @tgts = ();
     my @cmds = ();
     for(my $i=0; $i < @chrs; ++$i) {
@@ -421,24 +427,25 @@ else {
 		my $op = "$out.$chrs[$i].$start.$end";
 		my $region = "$chrs[$i]:$start-$end";
 		
-		my $tgt = "$op.epacts.gz";
-		my $cmd = "$epactsdir/bin/pEmmax multi-assoc-plain --vcf $cvcf --region $region --field $field --indf $ind --out-assocf $tgt --minMAF $minMAF --maxMAF $maxMAF --maxMAC $maxMAC --minRSQ $minRSQ --minCallRate $minCallRate --minMAC $minMAC --maxP $maxP --pheno $out.phe".($compact ? " --compact" : "");
+		my $tgt = "$op.epacts";
 		
-		#die "ERROR: Cannot find $datadir/multi.$test.R\n" unless ( -s "$datadir/multi.$test.R" );
+		die "ERROR: Cannot find $datadir/multi.$test.R\n" unless ( -s "$datadir/multi.$test.R" );
 
-		#$cmd = "$binRscript $datadir/epactsMulti.R --vanilla $epactsdir $pheno $cov $ind $cvcf $region $op.epacts $field $minMAF $maxMAF $minMAC $maxMAC $minCallRate $minRSQ ".(($pass) ? "TRUE" : "FALSE")." multi.$test; gzip $op.epacts";
+		my $cmd = "$binRscript $datadir/epactsMulti.R --vanilla $epactsdir $pheno $cov $ind $cvcf $region $op.epacts $field $minMAF $maxMAF $minMAC $maxMAC $minCallRate $minRSQ ".(($pass) ? "TRUE" : "FALSE")." multi.$test;";
+
+
 		if ( $mosixNodes ) { $cmd = &getMosixCmd($cmd,$mosixNodes); }
 		$cmd = "\t$cmd\n";
 
 		if ( $anno ) {
 		    if ( $mosixNodes ) { 
-			$cmd .= "\t".&getMosixCmd("$epactsdir/bin/epacts-anno --ref $ref --in $op.epacts.gz",$mosixNodes)."\n";
+			$cmd .= "\t".&getMosixCmd("$epactsdir/bin/epacts-anno --ref $ref --in $op.epacts",$mosixNodes)."\n";
 		    }
 		    else {
-			$cmd .= "\t$epactsdir/bin/epacts-anno --in $op.epacts.gz --ref $ref\n";
+			$cmd .= "\t$epactsdir/bin/epacts-anno --in $op.epacts --ref $ref\n";
 		    }
 		}
-		$cmd .= "\t$epactsdir/bin/tabix -f -pbed $tgt\n";
+		#$cmd .= "\t$epactsdir/bin/tabix -f -pbed $tgt\n";
 		push(@tgts,$tgt);
 		push(@cmds,$cmd);
 
@@ -448,19 +455,20 @@ else {
     }
 
     print MAK "all: $out.epacts.OK\n\n";
-    print MAK "$out.epacts.OK: ".join(".tbi ",@tgts).".tbi\n";
+    print MAK "$out.epacts.OK: @tgts\n";
     print MAK "\t$epactsdir/bin/epacts-cat @tgts | $epactsdir/bin/bgzip -c > $out.epacts.gz\n";
     print MAK "\t$epactsdir/bin/tabix -f -pbed $out.epacts.gz\n";
-    print MAK "\t$binrm -f @tgts ".join(".tbi ",@tgts).".tbi\n";
+    print MAK "\t$binrm -f @tgts\n";
     print MAK "\ttouch $out.epacts.OK\n";
     print MAK "\n";
     for(my $i=0; $i < @tgts; ++$i) {
-	print MAK "$tgts[$i].tbi: $vcf $ped\n";
-	print MAK "\tsleep ".sprintf("%.3lfs",rand(10))."\n";
+	print MAK "$tgts[$i]: $vcf $ped\n";
+	#print MAK "\tsleep ".sprintf("%.3lfs",rand(10))."\n";
 	print MAK "$cmds[$i]\n";
     }
     close MAK;
 }
+
 
 print "Finished generating EPACTS Makefile\n";
 if ( $run < 0 ) {

--- a/scripts/epacts-single
+++ b/scripts/epacts-single
@@ -303,6 +303,12 @@ if ( ( ! $sepchr ) && ( $vcf =~ /chr/ ) && ( ! $chr ) ) {
     print STDERR "*************************************************************************************\n";
 }
 
+if ( $test eq "b.sna2" ) {	#Analyze Null model
+my $cmdn = "$binRscript $datadir/epactsSingleNull.R --vanilla $out $pheno $cov;";
+if ( $mosixNodes ) { $cmdn = &getMosixCmd($cmdn,$mosixNodes); }
+&forkExecWait($cmdn);
+}
+
 open(MAK,">$out.Makefile") || die "Cannot open file $out.Makefile for writing\n";
 print MAK ".DELETE_ON_ERROR:\n\n";
 

--- a/scripts/epacts.pm
+++ b/scripts/epacts.pm
@@ -57,7 +57,12 @@ sub parsePheno {
 ## convert command to mosix command
 sub getMosixCmd {
     my ($cmd,$nodes) = @_;
-    return "mosbatch -E/tmp -i -j$nodes sh -c '$cmd'";
+    if ( $nodes =~ /srun/ ) { ## --mosixNodes "srun --partition=topmed-working --mem=13GB"
+	return "$nodes sh -c '$cmd'";
+    }
+    else {
+	return "mosbatch -E/tmp -i -j$nodes sh -c '$cmd'";
+    }
 }
 
 ## convert string chromosome to integer (compatible to PLINK)
@@ -503,7 +508,7 @@ sub readPedVcfMulti {
 	    my @p = ();
 	    for(my $j=0; $j < @iphes; ++$j) {
 		push(@p,&parsePheno($F[$iphes[$j]],$missing));
-		die "ERROR: Missing phenotype value is detected in individual $id, phenotype $rphes->[$j]. Currently EPACTS won't run with missing phenotypes\n" if ( $p[$#p] eq $missing );
+		#die "ERROR: Missing phenotype value is detected in individual $id, phenotype $rphes->[$j]. Currently EPACTS won't run with missing phenotypes\n" if ( $p[$#p] eq $missing );
 	    }
 	    $hPhes{$id} = \@p;
 	    


### PR DESCRIPTION
1. Implemented b.sna2 test for epacts-multi.
2. The null object for the b.sna2 test will only be calculated once and saved as .RData file. During the GWAS/PheWAS, epactsSingle.R/epactsMulti.R will only load pheno, genos, and the previously saved null object. This eliminates the computation of the null object for each chunk of SNPs, and significantly reduces computation times where calculating the null object is time consuming (when sample size is very large, eg. UKBioBank data). Moreover, it facilitates using smaller chunk sizes which is memory efficient for data with large sample sizes.
3. Implemented beta estimation for b.sna2 test. The beta parameters are estimated using Clement Ma's implementation of Firth's method, and therefore is a slow process. Beta parameters are only estimated when p < 5*10^-6.