### PR TITLE
Fix errors in write-ped

### DIFF
--- a/scripts/epacts-pca-plot
+++ b/scripts/epacts-pca-plot
@@ -120,7 +120,7 @@ if ( $writePed ) {
     }
     close EVECS;
 
-    open(OUT,">out.ped") || die "Cannot open $out.ped for writing\n";
+    open(OUT,">$out.ped") || die "Cannot open $out.ped for writing\n";
     while(<IN>) {
 	if ( /^#/ ) {
 	    chomp;
@@ -138,7 +138,7 @@ if ( $writePed ) {
 
 	    print OUT $_;
 	    print OUT "\t";
-	    print OUT join("\t",$hevecs{$id});
+	    print OUT join("\t",@{$hevecs{$id}});
 	    print OUT "\n";
 	}
     }


### PR DESCRIPTION
- use correct prefix instead of creating out.ped
- dereference `hevecs` array in order to join the PCs (now there is something like ARRAY(0x1234567)
 in out.ped)