### PR TITLE
Workaround to avoid LTB failure at pdf generation

### DIFF
--- a/data/prologue.ps
+++ b/data/prologue.ps
@@ -48,6 +48,8 @@
 % Default Line Types
 /LTw {PL [] 1 setgray} def
 /LTb {BL [] LCb DL} def
+% Workaround to avoid epstopdf failure
+/LTB {LTb} def
 /LTa {AL [1 udl mul 2 udl mul] 0 setdash LCa setrgbcolor} def
 /LT0 {PL [] LC0 DL} def
 /LT1 {PL [4 dl1 2 dl2] LC1 DL} def


### PR DESCRIPTION
There is currently an issue (#12 and #24) where PDFs don't get generated and an error is produced. 
I can't see the root cause of this, but adding a dummy line to prologue.ps to capture `LTB` works around the issue.