### PR TITLE
Build fix: Update Dockerfile to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
+
+# To suppress tzdata region prompt
+ARG DEBIAN_FRONTEND=noninteractive
 
 ENV SRC_DIR /tmp/epacts-src
 


### PR DESCRIPTION
The current Ubuntu 16.04 based build fails:

Step 7/13 : RUN cget install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" -f requirements.txt     && mkdir -p ${SRC_DIR}/build
 ---> Running in 0608c8b7e156
Traceback (most recent call last):
  File "/usr/local/bin/cget", line 7, in <module>
    from cget.cli import cli
  File "/usr/local/lib/python2.7/dist-packages/cget/cli.py", line 1, in <module>
    import click, os, functools, sys
ImportError: No module named click
The command '/bin/sh -c cget install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" -f requirements.txt     && mkdir -p ${SRC_DIR}/build' returned a non-zero code: 1

Updating to 18.04 seems to succeed

Signed-off-by: Sven-Thorsten Dietrich <thebigcorporation@gmail.com>