### PR TITLE
Drop "meta" from the command list

### DIFF
--- a/scripts/epacts
+++ b/scripts/epacts
@@ -86,7 +86,6 @@ epacts [command] [options]
    group           Perform groupwise (burden-style) association test
    anno            Annotate a VCF file
    zoom            Create a locus zoom plot from epacts results
-   meta            Perform meta-analysis across multiple epacts results
    make-group      Create the group information for gene-based testing
    make-kin        Create a kinship matrix
    version         prints version


### PR DESCRIPTION
This command is apparently not implemented, so remove from usage help.

Resolves: Issue #4

Signed-off-by: Sven-Thorsten Dietrich <thebigcorporation@gmail.com>