### PR TITLE
Updates to build on Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV SRC_DIR /tmp/epacts-src
 
@@ -13,8 +13,8 @@ RUN set -x \
         groff \
         help2man \
         lsb-release \
-        python \
-        python-pip \
+        python3 \
+        python3-pip \
         r-base \
         rpm \
     && pip install cget


### PR DESCRIPTION
 - in Ubuntu 20.04 python and associated packages have moved to 3.x

Signed-off-by: Sven-Thorsten Dietrich <thebigcorporation@gmail.com>