### PR TITLE
Return correct exit code when epacts help is called

### DIFF
--- a/scripts/epacts
+++ b/scripts/epacts
@@ -26,7 +26,7 @@ elsif ( $ARGV[0] =~ /^([\-])*man$/ ) {
     pod2usage(-verbose => 2);
 }
 elsif ( $ARGV[0] =~ /^([\-])*help$/ ) {
-    pod2usage(1);
+    pod2usage(0);
 }
 elsif ( $ARGV[0] eq "single") {
     shift(@ARGV);


### PR DESCRIPTION
 - epacts called without parameters correctly prints usage and
   exits with an error code 1
 - epacts help is a valid command and should return 0